### PR TITLE
[xyd/doc] update readme and add doc test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "submodules/drltt-assets"]
 	path = submodules/drltt-assets
-	url = git@github.com:MARMOTatZJU/drltt-assets.git
+	url = https://github.com/MARMOTatZJU/drltt-assets.git
 [submodule "submodules/waymax-visualization"]
 	path = submodules/waymax-visualization
-	url = git@github.com:MARMOTatZJU/waymax-visualization.git
+	url = https://github.com/MARMOTatZJU/waymax-visualization.git

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DRL-Based Trajectory Tracking (DRLTT)
+# DRL-based Trajectory Tracking (DRLTT)
 
 This repo hosts code and script for training and deploying the *DRL-Based Trajectory Tracking (DRLTT)* algorithm. DRLTT leverages Deep Reinforcement Learning (DRL) and achieves robustness, accuracy, and versatility in the Trajectory Tracking (TT) task in the context of Autonomous Driving. Benefiting from its methodological simplicity, DRLTT can process 32 trajectories (each contains 50 steps) within several milliseconds on edge computing devices.
 
@@ -12,10 +12,13 @@ Currently, DRLTT supports the following features:
   * Easy deployment and efficient inference of RL policy under a pure CPU environment.
   * Based on cpu-compiled *libtorch*.
   * See `./sdk`
-* A Python SDK
-  * Compatible with any Python environment, *No requirement* for any Python package.
-  * Based on *pybind*.
-  * See `./sdk/drltt-sdk/trajectory_tracker`
+* Two Python SDKs
+  * One based on Torch JIT
+    * Compatible with existing PyTorch environment
+    * See `./simulator/trajectory_tracker/trajectory_tracker.py`
+  * One based on C++ SDK
+    * Able to run standalone without PyTorch installation or other Python packages.
+    * See `sdk/assets/exported-python-sdk`
 
 ![idea-illustration](https://raw.githubusercontent.com/MARMOTatZJU/drltt-assets/main/images/drltt-idea-illustration.png)
 
@@ -45,6 +48,7 @@ Install Python requirement through `pip`:
 
 ```bash
 pip install -r requirements/pypi.txt
+pip install -r submodules/waymax-visualization/requirements.txt
 ```
 
 For network environments within Mainland China, you may consider using a domestic pip source to accelerate this process:

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,5 +1,11 @@
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
 version: "2"
 
+# build process
+# https://docs.readthedocs.io/en/stable/builds.html
+# https://docs.readthedocs.io/en/stable/build-customization.html
+
+# https://docs.readthedocs.io/en/stable/config-file/v2.html#build
 build:
   os: "ubuntu-22.04"
   tools:
@@ -12,11 +18,19 @@ build:
     pre_build:
       - bash ./setup.sh
 
-
+# https://docs.readthedocs.io/en/stable/config-file/v2.html#python-install
 python:
   install:
     - requirements: requirements/pypi.txt
     - requirements: requirements/pypi-doc.txt
+    - requirements: submodules/waymax-visualization/requirements.txt
 
+# https://docs.readthedocs.io/en/stable/config-file/v2.html#sphinx
 sphinx:
   configuration: docs/source/conf.py
+  fail_on_warning: True
+
+# https://docs.readthedocs.io/en/stable/config-file/v2.html#submodules
+submodules:
+  include: all
+  recursive: True

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,11 +1,6 @@
 # Documentation
 
-
 ## Sphinx
-
-This project adopts [Google-style Python docstrings](https://google.github.io/styleguide/pyguide.html), [Example Google Style Python Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for auto-generation of Python API pages.
-
-The authors would like to thank [PyTorch](https://pytorch.org/docs/stable/index.html) for being an exemplar of documentation.
 
 ### For initialization
 
@@ -20,6 +15,10 @@ Initialize Sphinx project:
 ```bash
 mkdir docs && cd docs
 sphinx-quickstart
+
+# Tips for the interactive configuration phase
+#   Choose the option "Separate sources from build"
+#   Reference: https://stackoverflow.com/questions/65829149/what-does-separate-source-and-build-directories-mean
 ```
 
 Build HTML:
@@ -37,7 +36,7 @@ As documentation of the current project has already been set up, you can only ru
   :language: bash
 
 
-### Start the server and view documentation pages
+### Start the server and view the documentation pages
 
 Start the HTTP server on the remote side
 
@@ -52,11 +51,128 @@ Create an SSH tunneling on the local side, which forwards connections/requests f
 ssh -L 8080:localhost:8080 remote-server
 ```
 
-## Doxygen
+## Use RST Files within the Sphinx Documentation
 
-Besides Sphinx, this project utilizes Doxygen for auto-generation of API pages of C++ SDK.
+### Include Markdown
+
+For including Markdown files into the Sphinx documentation, this project utilizes `m2r2` which needs to be installed through `pip`:
+
+```
+pip install m2r2
+```
+
+Then in `.rst` file, use the `.. mdinclude::` directive to include Markdown file. The path needs to be relative to the `.rst` file.
+
+```
+.. mdinclude:: ../../../README.md
+```
+
+### Include Code snippets
+
+Use the `.. literalinclude::` directive to include a code snippet from a script/source file.
+
+For example,
+
+```
+.. literalinclude:: ../../../make-html.sh
+  :language: bash
+```
+
+results in:
+
+.. literalinclude:: ../../../make-html.sh
+  :language: bash
+
+## Auto-Generation of API Documentations
+
+The feature of auto-documentation is realized by various Sphinx extensions and third-party tools.
+
+This project adopts [Google-style Python docstrings](https://google.github.io/styleguide/pyguide.html), [Example Google Style Python Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for auto-generation of Python API pages.
+
+The authors would like to thank [PyTorch](https://pytorch.org/docs/stable/index.html) for being an exemplar of documentation.
+
+Reference:
+
+* https://sphinx-rtd-theme.readthedocs.io/en/stable/demo/api.html
+
+### Python documentation
+
+Sphinx can utilize Napoleon for auto-generation of API pages of Python code.
+
+```python
+import os
+import sys
+sys.path.insert(0, os.path.abspath(path_to_python_module_dir))
+sys.path.insert(0, os.path.abspath(path_to_python_module2_dir))
+...
+
+extensions = [
+  ...
+  'sphinx.ext.autodoc',   # support for auto-doc generation
+  'sphinx.ext.napoleon',  # support for numpy / google style
+]
+```
+
+References:
+
+* https://sphinxcontrib-napoleon.readthedocs.io/en/latest/
+* https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html
+* https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html
+* https://sphinx-intro-tutorial.readthedocs.io/en/latest/sphinx_extensions.html
+
+
+
+### Doxygen documentation
+
+This project utilizes Doxygen for auto-generation of API pages of C++ SDK, and `breathe` for including these pages into the Sphinx documentation.
+
+`breathe` needs to be installed through `pip`:
+
+```bash
+pip install breath
+```
+
+Firstly, XML files are generated:
 
 ```bash
 cd sdk
 doxygen Doxyfile-cpp
 ```
+
+Then, in `conf.py`, set up `breathe` to include the XML generated in the previous step.
+
+```python
+extensions = [
+  "...",
+  "breathe",
+]
+sdk_name = "..."
+breathe_projects = { sdk_name: "../../sdk/doxygen_output/xml/" }
+breathe_default_project = sdk_name
+```
+
+Reference:
+
+* https://www.doxygen.nl/manual/starting.html
+* https://leimao.github.io/blog/CPP-Documentation-Using-Sphinx/
+  * https://github.com/leimao/Sphinx-CPP-TriangleLib
+* https://leimao.github.io/blog/CPP-Documentation-Using-Doxygen/
+  * https://github.com/leimao/Doxygen-CPP-TriangleLib
+
+
+
+### Protobuf documentation
+
+This project uses `protoc-gen-doc`, an extension of the Protobuf compiler, to automatically generate API pages for Protobuf definitions.
+
+To activate this extension, pass `--doc_out` argument to `protoc`.
+
+```bash
+protoc ... \
+    --doc_out ${doc_output_dir} \
+    ...
+```
+
+References:
+
+* https://github.com/pseudomuto/protoc-gen-doc

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,10 +16,12 @@ logging.basicConfig(level=logging.INFO)
 conf_py_file = os.path.dirname(__file__)
 project_dir = os.path.realpath(f'{conf_py_file}/../../')
 proto_dir = f'{project_dir}/common/proto/proto_gen_py'
+waymax_viz_dir = f'{project_dir}/submodules/waymax-visualization'  # TODO: consider move paths to a config files like YAML
 
 # Reference: https://stackoverflow.com/questions/10324393/sphinx-build-fail-autodoc-cant-import-find-module
 sys.path.append(project_dir)
 sys.path.append(proto_dir)
+sys.path.append(waymax_viz_dir)
 logging.info('sys.path:')
 for p in sys.path:
     logging.info(p)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,12 @@ Welcome to DRL-based Trajectory Tracking (DRLTT)'s documentation!
 
    rst_files/readme-sdk
 
+.. toctree::
+   :maxdepth: 3
+   :caption: Documentation Guide
+
+   rst_files/readme-docs
+
 
 .. Indices and tables
 .. ==================

--- a/docs/source/rst_files/readme-docs.rst
+++ b/docs/source/rst_files/readme-docs.rst
@@ -1,0 +1,1 @@
+.. mdinclude:: ../../../docs/README.md

--- a/make-html.sh
+++ b/make-html.sh
@@ -2,6 +2,12 @@
 source setup.sh
 
 pushd docs
-  make html
+  rm -rf build
+  make html SPHINXOPTS="-W"
+  make_sphinx_ret_val=$?
+  if [ $make_sphinx_ret_val -eq 0 ];then
+    echo "Built the Sphinx documentation successfully."
+  else
+    echo "Sphinx documentation building failed!!!"
+  fi
 popd
-

--- a/submodules/setup-submodules.sh
+++ b/submodules/setup-submodules.sh
@@ -6,3 +6,4 @@ export PYTHONPATH=:${drltt_proto_gen_py_dir_default}:${PYTHONPATH}
 waymax_viz_dir=submodules/waymax-visualization
 export PYTHONPATH=:${waymax_viz_dir}:${PYTHONPATH}
 
+echo "DRLTT submodule setup finished."

--- a/test-doc.sh
+++ b/test-doc.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+log_dir=./test-log
+mkdir -p $log_dir
+
+(
+    source setup.sh
+    bash make-html.sh
+) 2>&1 | tee ./${log_dir}/doc-test.log

--- a/test.sh
+++ b/test.sh
@@ -3,3 +3,5 @@
 ./test-python.sh "$@"
 
 ./test-cpp.sh "$@"
+
+./test-doc.sh "$@"


### PR DESCRIPTION
- readme of documentation
  - add content for readme of documentation - rst files: include markdonw/code snippets - auto-doc: python/cpp/protobuf - setup/reference
  - activate the corresponding page
- fix submodules import error in documentation
  - `conf.py` add paths in submodules to `sys.path`
  - submodules: move from ssh to http
    - so that RTD can clone them.
  - `.readthedocs.yaml`：waymax_viz requirements.txt
- make-html: warning as failure
- add test for documentation building
- update reamde
  - descriptions for python sdk
- .readthedocs.yml
  - add doc. comments
  - add fail_on_warning
  - add submodule
  - add reference to pages of configuration